### PR TITLE
Populate error.Error() when invoke CombinedOutput

### DIFF
--- a/client/base.go
+++ b/client/base.go
@@ -90,7 +90,7 @@ func HandleConnect(args ...string) error {
 	} else if len(args) == 1 {
 		// User only supply the LUN ID, so did a wildcard scan for all connected targets
 		err = fmt.Errorf("currently [lun id] is not supported")
-		log.WithError(err).Error("Unsupported parameters. {%s}", args)
+		log.WithError(err).Errorf("Unsupported parameters. {%s}", args)
 	} else {
 		target := args[0]
 		// Make sure the last param is LUN ID.

--- a/connector/fibre_channel.go
+++ b/connector/fibre_channel.go
@@ -56,7 +56,7 @@ func (fc *FibreChannelConnector) ConnectVolume(connectionProperty ConnectionProp
 	volumeInfo.MultipathId = lunWwn
 	volumeInfo.Multipath = mPath
 	volumeInfo.Paths, _ = goockutil.FilterPath(hostPaths)
-	log.Debug("ConnectVolume returning %s", volumeInfo)
+	log.Debugf("ConnectVolume returning %s", volumeInfo)
 
 	return volumeInfo, nil
 }

--- a/connector/iscsi.go
+++ b/connector/iscsi.go
@@ -225,7 +225,7 @@ func (iscsi *ISCSIConnector) ConnectVolume(connectionProperty ConnectionProperty
 		info.MultipathId = ""
 
 	}
-	log.Debug("ConnectVolume returning %s", info)
+	log.Debugf("ConnectVolume returning %s", info)
 	return info, nil
 
 }

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -34,6 +34,7 @@ func SetLogger(l *logrus.Logger) {
 // ErrExecutableNotFound is returned if the executable is not found.
 
 var ErrExecutableNotFound = osexec.ErrNotFound
+var ErrExitError = osexec.ExitError{}
 
 // Interface is an interface that presents a subset of the os/exec API.  Use this
 // when you want to inject fakeable/mockable exec behavior.
@@ -137,9 +138,16 @@ func executeCmd(cmd *cmdWrapper, combined bool) ([]byte, error) {
 		if err == ErrExecutableNotFound {
 			out = []byte(err.Error())
 		}
+
 		// out is EMPTY with call Output()
 		if combined != true {
 			out = []byte(err.Error())
+		}
+		// error.Error() is EMPTY when exitError
+		// so set the err.Error() to output
+		if eer, ok := err.(*ExitErrorWrapper); ok && combined {
+			eer.Stderr = out
+			//return out, err
 		}
 	}
 	log.WithFields(logrus.Fields{

--- a/gen_cover.sh
+++ b/gen_cover.sh
@@ -4,8 +4,8 @@ set -e
 echo "" > coverage.txt
 
 for d in $(go list ./... | grep -v -E "(test)|(vendor)"); do
-    go test -race -coverprofile=profile.out -covermode=atomic $d
-    if [ -f profile.out ]; then
+    go test -v -race -coverprofile=profile.out -covermode=atomic $d
+    if [[ -f profile.out ]]; then
         cat profile.out >> coverage.txt
         rm profile.out
     fi

--- a/test/mock_util.go
+++ b/test/mock_util.go
@@ -98,7 +98,14 @@ func (m *MockCmd) mockOutput() ([]byte, error) {
 	if file, err := os.Open(fileName); err == nil {
 
 		// make sure it gets closed
-		defer file.Close()
+		defer func() {
+			if file != nil {
+				errClose := file.Close()
+				if errClose != nil {
+					fmt.Printf("failed to close file: %s: %s", file.Name(), errClose.Error())
+				}
+			}
+		}()
 		fmt.Printf("Reading mock file: %s\n", fileName)
 
 		// create a new scanner and read the file line by line
@@ -127,8 +134,8 @@ func (m *MockCmd) mockOutput() ([]byte, error) {
 		}
 
 	} else {
-		fmt.Printf("Unable to read mock data from file %s, default to empty string.\n", fileName)
-		return []byte(""), fmt.Errorf("Unable to read mock file [%s]", fileName)
+		fmt.Printf("unable to read mock data from file %s(%q), default to empty string.\n", fileName, err.Error())
+		return []byte(""), fmt.Errorf("unable to read mock file [%s]", fileName)
 	}
 
 }


### PR DESCRIPTION
This commit populates the error with detailed message
when ExitError occurs so that Error() can log enough message for triage